### PR TITLE
Add support for manual OIDC authentication

### DIFF
--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -4,33 +4,35 @@ import abc
 
 import requests
 
+
 class BaseClientAuth(requests.auth.AuthBase):
     "Abstract class for authentication of api client"
     def __init__(self, app, location):
         self.app = app
-        self.location = location
+        self.location = app.service.proxy.list().entity["credentials_location"]
 
     @property
     @abc.abstractmethod
     def credentials(self):
         "returns credentials pair as tuple"
 
-    def __call__(self, r):
+    def __call__(self, request):
         credentials = self.credentials
 
         if self.location == "authorization":
             credentials = credentials.values()
             auth = requests.auth.HTTPBasicAuth(*credentials)
-            return auth(r)
+            return auth(request)
 
         if self.location == "headers":
-            r.prepare_headers(credentials)
+            request.prepare_headers(credentials)
         elif self.location == "query":
-            r.prepare_url(r.url, credentials)
+            request.prepare_url(request.url, credentials)
         else:
             raise ValueError("Unknown credentials location '%s'" % self.location)
 
-        return r
+        return request
+
 
 class UserKeyAuth(BaseClientAuth):
     "Provides user_key authentication for api client calls"
@@ -39,11 +41,11 @@ class UserKeyAuth(BaseClientAuth):
         return {
             self.app.service.proxy.list()["auth_user_key"]: self.app["user_key"]}
 
-    def __call__(self, r):
+    def __call__(self, request):
         if self.location == "authorization":
             auth = requests.auth.HTTPBasicAuth(next(iter(self.credentials.values())), "")
-            return auth(r)
-        return super().__call__(r)
+            return auth(request)
+        return super().__call__(request)
 
 
 class AppIdKeyAuth(BaseClientAuth):
@@ -54,10 +56,10 @@ class AppIdKeyAuth(BaseClientAuth):
             "app_id": self.app["application_id"],
             "app_key": self.app.keys.list()["keys"][0]["key"]["value"]}
 
-    def __call__(self, r):
+    def __call__(self, request):
         if self.location == "authorization":
             credentials = self.credentials
             auth = requests.auth.HTTPBasicAuth(
                 credentials["app_id"], credentials["app_key"])
-            return auth(r)
-        return super().__call__(r)
+            return auth(request)
+        return super().__call__(request)

--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -4,7 +4,6 @@ import abc
 
 import requests
 
-
 class BaseClientAuth(requests.auth.AuthBase):
     "Abstract class for authentication of api client"
     def __init__(self, app):

--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -7,7 +7,7 @@ import requests
 
 class BaseClientAuth(requests.auth.AuthBase):
     "Abstract class for authentication of api client"
-    def __init__(self, app, location):
+    def __init__(self, app):
         self.app = app
         self.location = app.service.proxy.list().entity["credentials_location"]
 

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -385,6 +385,10 @@ class Proxies(DefaultClient):
     def url(self) -> str:
         return self.parent.url + '/proxy'
 
+    @property
+    def oidc(self) -> 'OIDCConfig':
+        return OIDCConfig(self)
+
 
 class ProxyConfigs(DefaultClient):
     def __init__(self, *args, entity_name='proxy_config', entity_collection='configs',
@@ -477,11 +481,14 @@ class Policies(DefaultClient):
         params["service_id"] = self.parent["service_id"]
         self.update(params=params)
 
-class OIDCConfigs(DefaultClient):
+
+class OIDCConfig(DefaultClient):
     @property
     def url(self) -> str:
         return self.parent.url + '/oidc_configuration'
 
+    def update(self, params: dict = None, **kwargs) -> 'DefaultResource':
+        return self.rest.patch(url=self.url, json=params, **kwargs)
 
 # Resources
 
@@ -629,10 +636,6 @@ class Service(DefaultResource):
     def mapping_rules(self) -> 'MappingRules':
         return MappingRules(parent=self, instance_klass=MappingRule)
 
-    @property
-    def oidc(self):
-        return OIDCConfigs(self)
-
 
 class ActiveDoc(DefaultResource):
     def __init__(self, entity_name='system_name', **kwargs):
@@ -683,7 +686,7 @@ class Application(DefaultResource):
             return auth.AppIdKeyAuth(self, creds_location)
 
         if auth_mode == Service.AUTH_OIDC:
-            raise NotImplementedError("OpenID authentication not implemented yet.")
+            return None
 
         raise errors.ThreeScaleApiError(
             f"Unknown credentials for configuration {auth_mode}/{creds_location}")

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -386,8 +386,8 @@ class Proxies(DefaultClient):
         return self.parent.url + '/proxy'
 
     @property
-    def oidc(self) -> 'OIDCConfig':
-        return OIDCConfig(self)
+    def oidc(self) -> 'OIDCConfigs':
+        return OIDCConfigs(self)
 
 
 class ProxyConfigs(DefaultClient):
@@ -417,7 +417,7 @@ class ProxyConfigs(DefaultClient):
     def list(self, **kwargs):
         if "env" in kwargs:
             self._env = kwargs["env"]
-            del (kwargs["env"])
+            del(kwargs["env"])
         return super().list(**kwargs)
 
     def promote(self, version: int = 1, from_env: str = 'sandbox', to_env: str = 'production',
@@ -482,14 +482,13 @@ class Policies(DefaultClient):
         self.update(params=params)
 
 
-class OIDCConfig(DefaultClient):
+class OIDCConfigs(DefaultClient):
     @property
     def url(self) -> str:
         return self.parent.url + '/oidc_configuration'
 
     def update(self, params: dict = None, **kwargs) -> 'DefaultResource':
         return self.rest.patch(url=self.url, json=params, **kwargs)
-
 
 # Resources
 
@@ -656,7 +655,7 @@ class Tenant(DefaultResource):
 class Application(DefaultResource):
     def __init__(self, entity_name='system_name', **kwargs):
         super().__init__(entity_name=entity_name, **kwargs)
-        self.authobj_factories = {
+        self._auth_objects = {
             Service.AUTH_USER_KEY: auth.UserKeyAuth,
             Service.AUTH_APP_ID_KEY: auth.AppIdKeyAuth
         }
@@ -683,13 +682,13 @@ class Application(DefaultResource):
         svc = self.service
         auth_mode = svc["backend_version"]
 
-        if auth_mode not in self.authobj_factories:
+        if auth_mode not in self._auth_objects:
             raise errors.ThreeScaleApiError(f"Unknown credentials for configuration {auth_mode}")
 
-        return self.authobj_factories[auth_mode](self)
+        return self._auth_objects[auth_mode](self)
 
     def register_auth(self, auth_mode: str, factory):
-        self.authobj_factories[auth_mode] = factory
+        self._auth_objects[auth_mode] = factory
 
     def api_client(self, endpoint: str = "sandbox_endpoint",
                    session: requests.Session = None, verify: bool = None) -> 'utils.HttpClient':
@@ -725,7 +724,6 @@ class Application(DefaultResource):
         client = self.api_client(verify=verify)
 
         return client.get(relpath)
-
 
 class Account(DefaultResource):
     def __init__(self, entity_name='org_name', **kwargs):

--- a/threescale_api/utils.py
+++ b/threescale_api/utils.py
@@ -51,8 +51,7 @@ class HttpClient:
             session = requests.Session()
             self.retry_for_session(session)
 
-        if app.authobj is not None:
-            session.auth = app.authobj
+        session.auth = app.authobj
 
         if verify is not None:
             session.verify = verify
@@ -63,7 +62,7 @@ class HttpClient:
 
     @staticmethod
     def retry_for_session(session: requests.Session, total: int = 4):
-        retry = Retry(total=total, backoff_factor=1, status_forcelist=(503,), raise_on_status=True,
+        retry = Retry(total=total, backoff_factor=1, status_forcelist=(503,), raise_on_status=False,
                       respect_retry_after_header=False)
         adapter = HTTPAdapter(max_retries=retry)
         session.mount("https://", adapter)


### PR DESCRIPTION
- Add support for manual OIDC authentication.
  - Meaning user will have to add bearer token into headers manually, sadly full OIDC workflow would introduce another dependency used just for this.
- Extract adding retries to sessions into a separate method.
- Reintroduce `backoff_factor` into default `Session` object.
- Add `update` method to `OIDCConfig`.
- Move `oidc` from `Service` to `Proxy`.
