### PR TITLE
Make behavior of auth method compatible with older code

### DIFF
--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -6,9 +6,11 @@ import requests
 
 class BaseClientAuth(requests.auth.AuthBase):
     "Abstract class for authentication of api client"
-    def __init__(self, app):
+    def __init__(self, app, location=None):
         self.app = app
-        self.location = app.service.proxy.list().entity["credentials_location"]
+        self.location = location
+        if location is None:
+            self.location = app.service.proxy.list().entity["credentials_location"]
 
     @property
     @abc.abstractmethod

--- a/threescale_api/utils.py
+++ b/threescale_api/utils.py
@@ -51,7 +51,7 @@ class HttpClient:
             session = requests.Session()
             self.retry_for_session(session)
 
-        session.auth = app.authobj
+            session.auth = app.authobj
 
         if verify is not None:
             session.verify = verify


### PR DESCRIPTION
Recent change introduced few regressions that can break code using it.
Initialization of Auth object(s) was modified to still accept location
(if set) and session within HttpClient isn't altered if passed as arg.