### PR TITLE
property setter should preserve name of property (for api_client_verify)

### DIFF
--- a/tests/integration/test_integration_api_client.py
+++ b/tests/integration/test_integration_api_client.py
@@ -1,0 +1,7 @@
+def test_api_client(application, proxy):
+    application.api_client_verify = False
+    api_client = application.api_client()
+
+    assert api_client is not None
+    assert api_client._session.verify is False
+    assert api_client.get("/get").status_code == 200

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -724,7 +724,7 @@ class Application(DefaultResource):
         return self._api_client_verify
 
     @api_client_verify.setter
-    def set_api_client_verify(self, value: bool):
+    def api_client_verify(self, value: bool):
         self._api_client_verify = value
 
     def test_request(self, relpath=None, verify: bool = None):


### PR DESCRIPTION
same name of function should be used for both @property as well as for
@property.setter

Added also basic test to verify functionality of api_client_verify
property.