### PR TITLE
AppIdKeyAuth improvements

### DIFF
--- a/tests/integration/auth/test_app_key.py
+++ b/tests/integration/auth/test_app_key.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def service_params(service_params):
+    service_params.update(backend_version="2")
+    return service_params
+
+
+def test_user_key(proxy, apicast_http_client):
+    assert apicast_http_client.get("/get").status_code == 200

--- a/tests/integration/auth/test_app_key_authorization.py
+++ b/tests/integration/auth/test_app_key_authorization.py
@@ -1,0 +1,27 @@
+import base64
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def service_params(service_params):
+    service_params.update(backend_version="2")
+    return service_params
+
+
+@pytest.fixture(scope="module")
+def proxy(service, proxy):
+    service.proxy.update(params={
+        "credentials_location": "authorization"
+    })
+
+
+def test_app_key_authorization(proxy, application, ssl_verify):
+    creds = application.authobj.credentials
+    encoded = base64.b64encode(
+        f"{creds['app_id']}:{creds['app_key']}".encode("utf-8")).decode("utf-8")
+
+    response = application.test_request(verify=ssl_verify)
+
+    assert response.status_code == 200
+    assert response.request.headers["Authorization"] == "Basic %s" % encoded

--- a/tests/integration/auth/test_different_app_key_name.py
+++ b/tests/integration/auth/test_different_app_key_name.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def service_params(service_params):
+    service_params.update(backend_version="2")
+    return service_params
+
+
+@pytest.fixture(scope="module")
+def proxy(service, proxy):
+    service.proxy.update(params={
+        "auth_app_key": "akey",
+        "auth_app_id": "aid",
+    })
+
+
+def test_different_user_key(proxy, application, ssl_verify):
+    client = application.api_client(verify=ssl_verify)
+
+    response = client.get("/get")
+    assert response.status_code == 200
+    assert "akey" in response.request.url
+    assert "aid" in response.request.url

--- a/tests/integration/auth/test_different_user_key_name.py
+++ b/tests/integration/auth/test_different_user_key_name.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def proxy(service, proxy):
+    service.proxy.update(params={"auth_user_key": "ukey"})
+
+
+def test_different_user_key(proxy, application, ssl_verify):
+    client = application.api_client(verify=ssl_verify)
+
+    response = client.get("/get")
+    assert response.status_code == 200
+    assert "ukey" in response.request.url

--- a/tests/integration/auth/test_user_key.py
+++ b/tests/integration/auth/test_user_key.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def service_params(service_params):
+    service_params.update(backend_version="1")
+    return service_params
+
+
+def test_user_key(proxy, apicast_http_client):
+    assert apicast_http_client.get("/get").status_code == 200

--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -53,15 +53,11 @@ class AppIdKeyAuth(BaseClientAuth):
 
     def __init__(self, app, location=None):
         super(AppIdKeyAuth, self).__init__(app, location)
+        proxy = self.app.service.proxy.list()
         self.credentials = {
-            "app_id": self.app["application_id"],
-            "app_key": self.app.keys.list()["keys"][0]["key"]["value"]
+            proxy["auth_app_id"]: self.app["application_id"],
+            proxy["auth_app_key"]: self.app.keys.list()["keys"][0]["key"]["value"]
         }
 
     def __call__(self, request):
-        if self.location == "authorization":
-            credentials = self.credentials
-            auth = requests.auth.HTTPBasicAuth(
-                credentials["app_id"], credentials["app_key"])
-            return auth(request)
         return super().__call__(request)


### PR DESCRIPTION
* The values for the authorization names are now fetched from the proxy instead of being fixed values.
* The special handling of `authorization` for `AppIdKeyAuth` was removed because the `BaseClientAuth` does the same thing.
* Added integration tests for auth to make sure I didn't break anything.