### PR TITLE
Refactor HttpClient for working with ssl

### DIFF
--- a/threescale_api/__init__.py
+++ b/threescale_api/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 from .client import ThreeScaleClient
 
-__version__ = '0.3.6'
+__version__ = '0.3.7'


### PR DESCRIPTION
Some parameters available in `kwargs` were not expected by `requests.Request` which fails when trying to instantiate it. Define all required parameters explicitly in the function's signature.