### PR TITLE
Add activedoc for service

### DIFF
--- a/tests/integration/test_integration_services.py
+++ b/tests/integration/test_integration_services.py
@@ -102,3 +102,6 @@ def test_service_mapping_rules(service):
 
 def test_service_backend_usages_backend(backend_usage, backend):
     assert backend_usage.backend.entity_id == backend.entity_id
+
+def test_service_active_docs(service, active_doc):
+    assert all([acs['service_id'] == service['id'] for acs in service.active_docs.list()])

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 import requests
 
@@ -761,6 +761,19 @@ class Service(DefaultResource):
     @property
     def backend_usages(self) -> 'BackendUsages':
         return BackendUsages(parent=self, instance_klass=BackendUsage)
+
+    @property
+    def active_docs(self) -> 'ActiveDocs':
+        """ Active docs related to service. """
+        up_self = self
+
+        class Wrap(ActiveDocs):
+            def list(self, **kwargs) -> List['DefaultResource']:
+                """List all ActiveDocs related to this service."""
+                kwargs.update({'service_id': up_self['id']})
+                instance = self.select_by(**kwargs)
+                return instance
+        return Wrap(parent=self, instance_klass=ActiveDoc)
 
 
 class ActiveDoc(DefaultResource):


### PR DESCRIPTION
Adds link to activedocs from service/product. These activedocs are related to service/product. There is `Wrapper` class for evaluation in time of calling function `list` in PR.