### PR TITLE
add reading of oidc setup, return json instead of response from update

### DIFF
--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -518,13 +518,13 @@ class Policies(DefaultClient):
 class OIDCConfigs(DefaultClient):
     @property
     def url(self) -> str:
-        return self.parent.url + '/proxy/oidc_configuration'
+        return self.parent.url + '/oidc_configuration'
 
-    def update(self, params: dict = None, **kwargs) -> 'DefaultResource':
-        return self.rest.patch(url=self.url, json=params, **kwargs).json()
+    def update(self, params: dict = None, **kwargs) -> requests.Response:
+        return self.rest.patch(url=self.url, json=params, **kwargs)
 
-    def read(self, params: dict = None, **kwargs) -> 'DefaultResource':
-        return self.rest.get(url=self.url, json=params, **kwargs).json()
+    def read(self, params: dict = None, **kwargs) -> requests.Response:
+        return self.rest.get(url=self.url, json=params, **kwargs)
 
 
 class Backends(DefaultClient):
@@ -909,7 +909,7 @@ class Service(DefaultResource):
         return PoliciesRegistry(parent=self, instance_klass=PoliciesRegistry)
 
     def oidc(self):
-        return OIDCConfigs(self)
+        return self.proxy.oidc
 
     @property
     def backend_usages(self) -> 'BackendUsages':

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -518,10 +518,13 @@ class Policies(DefaultClient):
 class OIDCConfigs(DefaultClient):
     @property
     def url(self) -> str:
-        return self.parent.url + '/oidc_configuration'
+        return self.parent.url + '/proxy/oidc_configuration'
 
     def update(self, params: dict = None, **kwargs) -> 'DefaultResource':
-        return self.rest.patch(url=self.url, json=params, **kwargs)
+        return self.rest.patch(url=self.url, json=params, **kwargs).json()
+
+    def read(self, params: dict = None, **kwargs) -> 'DefaultResource':
+        return self.rest.get(url=self.url, json=params, **kwargs).json()
 
 
 class Backends(DefaultClient):

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -520,11 +520,11 @@ class OIDCConfigs(DefaultClient):
     def url(self) -> str:
         return self.parent.url + '/oidc_configuration'
 
-    def update(self, params: dict = None, **kwargs) -> requests.Response:
-        return self.rest.patch(url=self.url, json=params, **kwargs)
+    def update(self, params: dict = None, **kwargs) -> dict:
+        return self.rest.patch(url=self.url, json=params, **kwargs).json()
 
-    def read(self, params: dict = None, **kwargs) -> requests.Response:
-        return self.rest.get(url=self.url, json=params, **kwargs)
+    def read(self, params: dict = None, **kwargs) -> dict:
+        return self.rest.get(url=self.url, json=params, **kwargs).json()
 
 
 class Backends(DefaultClient):


### PR DESCRIPTION
Adding "json" response to update is OK because I've check all usages in the Testsuite.
Adding read is needed for checking correctness of imported services from OAS.