### PR TITLE
WIP: Add update_credentials method to auth objects

### DIFF
--- a/threescale_api/auth.py
+++ b/threescale_api/auth.py
@@ -1,31 +1,44 @@
 # pylint: disable=R0903
 """Implementation of custom 3scale specific authentication method(s) for requests (api clients"""
+from abc import ABC, abstractmethod
 
 import requests
 import requests.auth
 
 
-class BaseClientAuth(requests.auth.AuthBase):
-    """Abstract class for authentication of api client"""
+class ThreescaleBaseClientAuth(ABC):
+    """Abstract class for Auth client"""
 
     def __init__(self, app, location=None):
         self.app = app
         self.location = location
-        if location is None:
+        self.credentials = {}
+
+    @abstractmethod
+    def update_credentials(self, app):
+        """Updates the application of the auth object"""
+        self.app = app
+
+
+class BaseClientAuth(ThreescaleBaseClientAuth, requests.auth.AuthBase):
+    """Abstract class for authentication of api client"""
+
+    def update_credentials(self, app):
+        super().update_credentials(app)
+        if self.location is None:
             self.location = app.service.proxy.list().entity["credentials_location"]
 
     def __call__(self, request):
-        credentials = self.credentials
 
         if self.location == "authorization":
-            credentials = credentials.values()
+            credentials = self.credentials.values()
             auth = requests.auth.HTTPBasicAuth(*credentials)
             return auth(request)
 
         if self.location == "headers":
-            request.prepare_headers(credentials)
+            request.prepare_headers(self.credentials)
         elif self.location == "query":
-            request.prepare_url(request.url, credentials)
+            request.prepare_url(request.url, self.credentials)
         else:
             raise ValueError("Unknown credentials location '%s'" % self.location)
 
@@ -37,6 +50,9 @@ class UserKeyAuth(BaseClientAuth):
 
     def __init__(self, app, location=None):
         super(UserKeyAuth, self).__init__(app, location)
+
+    def update_credentials(self, app):
+        super(UserKeyAuth, self).update_credentials(app)
         self.credentials = {
             self.app.service.proxy.list()["auth_user_key"]: self.app["user_key"]
         }
@@ -53,6 +69,9 @@ class AppIdKeyAuth(BaseClientAuth):
 
     def __init__(self, app, location=None):
         super(AppIdKeyAuth, self).__init__(app, location)
+
+    def update_credentials(self, app):
+        super(AppIdKeyAuth, self).update_credentials(app)
         proxy = self.app.service.proxy.list()
         self.credentials = {
             proxy["auth_app_id"]: self.app["application_id"],


### PR DESCRIPTION
## Why?
We need to have a standard interface to work with auth objects to introduce or rewrite them efficiently.
Right now the `authobj` method is calling 
```py
return self._auth_objects[auth_mode](self)
```
which implies that auth object must be a reference to a class or the object must override the `__call__` method. This creates some unwanted behaviors you need to implement if you want to create your own auth class.

## What?
This PR introduces a new interface `ThreescaleBaseClientAuth` which has only 1 method `update_credentials(app)`.
This method aims to update credentials saved in the auth object.

We need to call this method in the `authobj` to update credentials because, after the application was created, the service auth can be changed from user key to app id, and we need to make sure that credentials of auth object are updated.
