### PR TITLE
Add AccessToken endpoint and properties for accessing tokens

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,6 +87,20 @@ def service(service_params, api) -> Service:
 
 
 @pytest.fixture(scope='module')
+def access_token_params()-> dict:
+    suffix = get_suffix()
+    name = f"test-{suffix}"
+    return dict(name=name, permission="rw", scopes=["account_management"])
+
+
+@pytest.fixture(scope='module')
+def access_token(access_token_params, api):
+    entity = api.access_tokens.create(params=access_token_params)
+    yield entity
+    cleanup(entity)
+
+
+@pytest.fixture(scope='module')
 def account_params():
     suffix = get_suffix()
     name = f"test-{suffix}"

--- a/tests/integration/test_integration_access_token.py
+++ b/tests/integration/test_integration_access_token.py
@@ -1,0 +1,23 @@
+from . import asserts
+
+def test_access_tokens_list(api, access_token):
+    access_tokens = api.access_tokens.list()
+    assert len(access_tokens) >= 1
+
+
+def test_access_token_can_be_created(api, access_token, access_token_params):
+    asserts.assert_resource(access_token)
+    asserts.assert_resource_params(access_token, access_token_params)
+
+
+def test_access_token_can_be_read(api, access_token, access_token_params):
+    read = api.access_tokens.read(access_token.entity_id)
+    asserts.assert_resource(read)
+    asserts.assert_resource_params(read, access_token_params)
+
+
+def test_access_token_can_be_read_by_name(api, access_token, access_token_params):
+    access_token_name = access_token["name"]
+    read = api.access_tokens[access_token_name]
+    asserts.assert_resource(read)
+    asserts.assert_resource_params(read, access_token_params)

--- a/threescale_api/client.py
+++ b/threescale_api/client.py
@@ -27,6 +27,8 @@ class ThreeScaleClient:
         self._analytics = resources.Analytics(self)
         self._tenants = resources.Tenants(self, instance_klass=resources.Tenant)
         self._providers = resources.Providers(self, instance_klass=resources.Provider)
+        self._access_tokens = \
+            resources.AccessTokens(self, instance_klass=resources.AccessToken)
         self._active_docs = resources.ActiveDocs(self, instance_klass=resources.ActiveDoc)
         self._account_plans = resources.AccountPlans(self, instance_klass=resources.AccountPlan)
         self._settings = resources.SettingsClient(self)
@@ -64,6 +66,14 @@ class ThreeScaleClient:
         Returns(str): URL
         """
         return self._rest.url
+
+    @property
+    def url_with_token(self) -> str:
+        return self.rest.url.replace('//', f"//{self.rest._token}@")
+
+    @property
+    def token(self) -> str:
+        return self.rest._token
 
     @property
     def admin_api_url(self) -> str:
@@ -134,6 +144,13 @@ class ThreeScaleClient:
         Returns(resources.Providers): Providers client
         """
         return self._providers
+
+    @property
+    def access_tokens(self) -> resources.AccessTokens:
+        """Gets AccessTokens client
+        Returns(resources.AccessToken): AccessTokens client
+        """
+        return self._access_tokens
 
     @property
     def tenants(self) -> resources.Tenants:

--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -331,6 +331,17 @@ class Providers(DefaultClient):
         return utils.extract_response(response=response)
 
 
+class AccessTokens(DefaultClient):
+    def __init__(self, *args, entity_name='access_token', entity_collection='access_tokens',
+                 **kwargs):
+        super().__init__(*args, entity_name=entity_name,
+                         entity_collection=entity_collection, **kwargs)
+
+    @property
+    def url(self) -> str:
+        return self.threescale_client.admin_api_url + '/personal/access_tokens'
+
+
 class ActiveDocs(DefaultClient):
     def __init__(self, *args, entity_name='api_doc', entity_collection='api_docs', **kwargs):
         super().__init__(*args, entity_name=entity_name,
@@ -935,6 +946,11 @@ class ActiveDoc(DefaultResource):
 
 class Provider(DefaultResource):
     def __init__(self, entity_name='org_name', **kwargs):
+        super().__init__(entity_name=entity_name, **kwargs)
+
+
+class AccessToken(DefaultResource):
+    def __init__(self, entity_name='name', **kwargs):
         super().__init__(entity_name=entity_name, **kwargs)
 
 


### PR DESCRIPTION
create_token in PersonalAccesses will allow creation of new Personal Access Token like:
```
access_token = my_client.personal_accesses.create_token([
        ("name", "token_name"),
        ("permission", "rw"),
        ("scopes[]", "finance"),
        ("scopes[]", "account_management"),
        ("scopes[]", "stats"),
        ("scopes[]", "policy_registry")
    ])
```
Then  `access_token["access_token"]["value"]` contains the actual token

Signed-off-by: Matej Dujava <mdujava@redhat.com>